### PR TITLE
Modified jsonPointer to create an empty Array for new integer key

### DIFF
--- a/flagrate.js
+++ b/flagrate.js
@@ -67,20 +67,28 @@
 		},
 		traverse: function (obj, pointer, value, isSet) {
 			var part = jsonPointer.untilde(pointer.shift());
+			if (part.match(/^\d+$/)) part = parseInt(part);
 			
 			if (pointer.length !== 0) {// keep traversin!
 				if (isSet && typeof obj[part] !== 'object') {
-					obj[part] = {};
+					if (value == null) {
+						return value;
+					}
+					if (pointer[0].match(/^\d+$/)) {
+						obj[part] = [];
+					} else {
+						obj[part] = {};
+					}
 				}
 				return jsonPointer.traverse(obj[part], pointer, value, isSet);
 			}
 			// we're done
-			if (value === void 0) {
+			if (!isSet) {
 				// just reading
 				return obj[part];
 			}
 			// set new value, and return
-			if (value === null) {
+			if (value == null) {
 				delete obj[part];
 			} else {
 				obj[part] = value;


### PR DESCRIPTION
In the original behavior, setting an undefined value acts just same way as getting the current value (non-destructive). But it will act as 'unset' the same way as to set a null value (destructive) after merging this commit.
