### PR TITLE
Fix border-radius in Chrome62 on macOS

### DIFF
--- a/src/css/flagrate/button.less
+++ b/src/css/flagrate/button.less
@@ -3,6 +3,7 @@ button.flagrate-button {
     cursor: pointer;
     padding: 0 11px;
     border: 1px solid transparent;
+    border-radius: 0;
     color: @shape-inverse;
     background-repeat: no-repeat;
     background-position: 5px center;


### PR DESCRIPTION
`border-radius` has been added to the button of macOS Chrome 62.
I disabled it.

https://www.chromestatus.com/feature/5743649186906112

|before|after|
|:---|:---|
|![border-radius1](https://user-images.githubusercontent.com/8241257/32424491-2c163a1e-c2f0-11e7-81a0-d30b70445991.png)|![border-radius2](https://user-images.githubusercontent.com/8241257/32424523-4ff073d2-c2f0-11e7-8810-ee9f31ef7094.png)|